### PR TITLE
fix: Correct spacing issue between Show More button and footer, corre…

### DIFF
--- a/src/pages/Events.tsx
+++ b/src/pages/Events.tsx
@@ -103,7 +103,6 @@ const Events: React.FC = () => {
   ];  
 
   const [visibleEvents, setVisibleEvents] = useState(5); // Number of visible concerts at the start
-  //const percentage = (visibleEvents / events.length) * 100; // Show progress bar
 
   // Function to load more concerts
   const loadMoreEvents = () => {
@@ -111,14 +110,14 @@ const Events: React.FC = () => {
   };
 
   return (
-    <div className="min-h-screen flex flex-col">
+    <div className="bg-white">
       {/* Mostrar el total de productos y los visibles en la misma línea */}
-      <div className="ml-10  mr-10 flex justify-between items-center text-lg font-semibold pt-8">
+      <div className="ml-10 mr-10 flex justify-between items-center text-lg font-semibold pt-8">
         <div>{events.length} Products</div>
         <div className="flex items-center gap-2">Show {visibleEvents} products <FaChevronDown /></div>
       </div>
   
-      <div className="flex-grow p-8 bg-white">
+      <div className="p-8 bg-white">
         {/* Mostrar los conciertos */}
         <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-4 lg:grid-cols-5 gap-8">
           {events.slice(0, visibleEvents).map((event, index) => (
@@ -152,7 +151,7 @@ const Events: React.FC = () => {
 
         {/* Botón Show More */}
         {visibleEvents < events.length && (
-          <div className="flex justify-center items-center mt-12 px-4">
+          <div className="flex justify-center items-center mt-12 mb-8">
             <Button
               label={
                 <>


### PR DESCRIPTION
This commit fixes the excessive white space between the Show More button and the footer on the Events page and the inexactly background color

Changes made:
- Removed min-h-screen from main container to prevent forced full-height display
- Eliminated flex-grow property that was expanding content unnecessarily
- Added proper margin-bottom to the Show More button container
- Simplified container structure by removing unnecessary flex classes
- Added the correct color white to the bg